### PR TITLE
Remove last slash

### DIFF
--- a/lumo-ui/plugin/src/main/java/com/nomanr/lumo/plugin/configs/ConfigurationValidator.kt
+++ b/lumo-ui/plugin/src/main/java/com/nomanr/lumo/plugin/configs/ConfigurationValidator.kt
@@ -15,10 +15,10 @@ class ConfigurationValidator(private val project: Project, private val logger: L
         }
 
         val normalizedDirPath = config.componentsDir
+            .removeSuffix("/").removeSuffix("\\") // Remove the last slash or backslash
             .replace("\\", ".") // Replace Windows-style backslashes
             .replace("/", ".")  // Replace Unix-style forward slashes
             .replace("//", ".") // Handle double forward slashes (if any)
-            .removeSuffix("/").removeSuffix("\\") // Remove last slash
 
 
 

--- a/lumo-ui/plugin/src/main/java/com/nomanr/lumo/plugin/configs/ConfigurationValidator.kt
+++ b/lumo-ui/plugin/src/main/java/com/nomanr/lumo/plugin/configs/ConfigurationValidator.kt
@@ -18,6 +18,7 @@ class ConfigurationValidator(private val project: Project, private val logger: L
             .replace("\\", ".") // Replace Windows-style backslashes
             .replace("/", ".")  // Replace Unix-style forward slashes
             .replace("//", ".") // Handle double forward slashes (if any)
+            .removeSuffix("/").removeSuffix("\\") // Remove last slash
 
 
 


### PR DESCRIPTION
The `ComponentsDir` in `lumo.properties` should be allowed to have a trailing slash.

